### PR TITLE
Implemented mirroring of Y-axis when front camera is used (with config toggles)

### DIFF
--- a/camerakit/src/main/api16/com/flurgle/camerakit/Camera1.java
+++ b/camerakit/src/main/api16/com/flurgle/camerakit/Camera1.java
@@ -197,9 +197,19 @@ public class Camera1 extends CameraImpl {
             case METHOD_STANDARD:
                 mCamera.takePicture(null, null, null, new Camera.PictureCallback() {
                     @Override
-                    public void onPictureTaken(byte[] data, Camera camera) {
-                        mCameraListener.onPictureTaken(data);
-                        camera.startPreview();
+                    public void onPictureTaken(byte[] data, final Camera camera) {
+                        if (mFacing == CameraKit.Constants.FACING_FRONT) {
+                            new Thread(new MirrorYTask(data, new MirrorYTask.OnMirrorYDoneListener() {
+                                @Override
+                                public void onMirrorYDone(byte[] correctedData) {
+                                    mCameraListener.onPictureTaken(correctedData);
+                                    camera.startPreview();
+                                }
+                            })).start();
+                        } else {
+                            mCameraListener.onPictureTaken(data);
+                            camera.startPreview();
+                        }
                     }
                 });
                 break;
@@ -360,7 +370,7 @@ public class Camera1 extends CameraImpl {
                 getCaptureResolution().getHeight()
         );
         int rotation = (calculateCameraRotation(mDisplayOrientation)
-                + (mFacing == CameraKit.Constants.FACING_FRONT ? 180 : 0) ) % 360;
+                + (mFacing == CameraKit.Constants.FACING_FRONT ? 180 : 0)) % 360;
         mCameraParameters.setRotation(rotation);
 
         setFocus(mFocus);

--- a/camerakit/src/main/api16/com/flurgle/camerakit/Camera1.java
+++ b/camerakit/src/main/api16/com/flurgle/camerakit/Camera1.java
@@ -198,7 +198,7 @@ public class Camera1 extends CameraImpl {
                 mCamera.takePicture(null, null, null, new Camera.PictureCallback() {
                     @Override
                     public void onPictureTaken(byte[] data, final Camera camera) {
-                        if (mFacing == CameraKit.Constants.FACING_FRONT) {
+                        if (mConfig.mMirrorYAxisForFrontCamera && mFacing == CameraKit.Constants.FACING_FRONT) {
                             new Thread(new MirrorYTask(data, new MirrorYTask.OnMirrorYDoneListener() {
                                 @Override
                                 public void onMirrorYDone(byte[] correctedData) {

--- a/camerakit/src/main/api16/com/flurgle/camerakit/MirrorYTask.java
+++ b/camerakit/src/main/api16/com/flurgle/camerakit/MirrorYTask.java
@@ -1,0 +1,43 @@
+package com.flurgle.camerakit;
+
+import android.graphics.Bitmap;
+import android.graphics.BitmapFactory;
+import android.graphics.Matrix;
+
+import java.io.ByteArrayOutputStream;
+
+public class MirrorYTask implements Runnable {
+
+    private byte[] data;
+    private OnMirrorYDoneListener onMirrorYDoneListener;
+
+    public MirrorYTask(byte[] data, OnMirrorYDoneListener onMirrorYDoneListener) {
+        this.data = data;
+        this.onMirrorYDoneListener = onMirrorYDoneListener;
+    }
+
+    @Override
+    public void run() {
+        Bitmap rawImage = BitmapFactory.decodeByteArray(data, 0, data.length);
+
+        float[] mirrorY = {-1, 0, 0, 0, 1, 0, 0, 0, 1};
+        Matrix matrix = new Matrix();
+        Matrix matrixMirrorY = new Matrix();
+        matrixMirrorY.setValues(mirrorY);
+        matrix.postConcat(matrixMirrorY);
+
+        Bitmap correctedImage = Bitmap.createBitmap(rawImage, 0, 0, rawImage.getWidth(), rawImage.getHeight(), matrix, true);
+        rawImage.recycle();
+
+        ByteArrayOutputStream stream = new ByteArrayOutputStream();
+        correctedImage.compress(Bitmap.CompressFormat.JPEG, 100, stream);
+        byte[] correctedData = stream.toByteArray();
+
+        onMirrorYDoneListener.onMirrorYDone(correctedData);
+    }
+
+    interface OnMirrorYDoneListener {
+
+        void onMirrorYDone(byte[] correctedData);
+    }
+}

--- a/camerakit/src/main/base/com/flurgle/camerakit/CameraImpl.java
+++ b/camerakit/src/main/base/com/flurgle/camerakit/CameraImpl.java
@@ -4,10 +4,19 @@ abstract class CameraImpl {
 
     protected final CameraListener mCameraListener;
     protected final PreviewImpl mPreview;
+    protected Config mConfig = new Config.Builder().build(); //Build a default config, so we have default values and this object is never null
 
     CameraImpl(CameraListener callback, PreviewImpl preview) {
         mCameraListener = callback;
         mPreview = preview;
+    }
+
+    public void setConfig(Config config) {
+        if (config != null) {
+            this.mConfig = config;
+        } else {
+            throw new NullPointerException("Config can not be null. If no config is set, a default one will be used");
+        }
     }
 
     abstract void start();

--- a/camerakit/src/main/base/com/flurgle/camerakit/Config.java
+++ b/camerakit/src/main/base/com/flurgle/camerakit/Config.java
@@ -1,0 +1,28 @@
+package com.flurgle.camerakit;
+
+public class Config {
+
+    public boolean mMirrorYAxisForFrontCamera = false;
+
+    private Config() {
+
+    }
+
+    public static class Builder {
+
+        private Config config;
+
+        public Builder() {
+            config = new Config();
+        }
+
+        public Builder setMirrorYAxisForFrontCamera(boolean mirrorYAxisForFrontCamera) {
+            config.mMirrorYAxisForFrontCamera = mirrorYAxisForFrontCamera;
+            return this;
+        }
+
+        public Config build() {
+            return config;
+        }
+    }
+}

--- a/camerakit/src/main/java/com/flurgle/camerakit/CameraView.java
+++ b/camerakit/src/main/java/com/flurgle/camerakit/CameraView.java
@@ -208,6 +208,10 @@ public class CameraView extends FrameLayout {
         this.mCropOutput = cropOutput;
     }
 
+    public void setConfig(Config config) {
+        mCameraImpl.setConfig(config);
+    }
+
     @Facing
     public int toggleFacing() {
         switch (mFacing) {

--- a/demo/src/main/java/com/flurgle/camerakit/demo/MainActivity.java
+++ b/demo/src/main/java/com/flurgle/camerakit/demo/MainActivity.java
@@ -18,6 +18,7 @@ import android.widget.Toast;
 import com.flurgle.camerakit.CameraKit;
 import com.flurgle.camerakit.CameraListener;
 import com.flurgle.camerakit.CameraView;
+import com.flurgle.camerakit.Config;
 
 import java.io.File;
 
@@ -87,6 +88,10 @@ public class MainActivity extends AppCompatActivity implements View.OnLayoutChan
         });
 
         camera.addOnLayoutChangeListener(this);
+        
+        camera.setConfig(new Config.Builder()
+                .setMirrorYAxisForFrontCamera(true)
+                .build());
 
         captureModeRadioGroup.setOnCheckedChangeListener(captureModeChangedListener);
         cropModeRadioGroup.setOnCheckedChangeListener(cropModeChangedListener);


### PR DESCRIPTION
Currently when an image is taken with the front camera, the image is mirrored on the Y-axis, as this is how the camera sensor sees the image.
But this is not how the user would expect it to look.

I implemented a way to mirror the image correctly, so you get a correct image.

I added a Config class to be able to enable/disable the feature.

I'm not sure as how to implement the same logic with images taken by the STILL method, as it uses YUV and im not familiar with that type.

As the image needs to be mirrored, it does take a small amount of time to do this, everything is done async so the UI still does not lag.